### PR TITLE
chore(deps): bump copier project template to v0.4.2-63-g9f35f75

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.4.2-61-g734a769
+_commit: v0.4.2-63-g9f35f75
 _src_path: git+https://github.com/twsl/python-project-template
 author_email: 45483159+twsl@users.noreply.github.com
 author_username: twsl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pre-commit-update
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.17
+    rev: 0.11.18
     hooks:
       - id: uv-lock
 
@@ -64,7 +64,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/allganize/ty-pre-commit
-    rev: v0.0.40
+    rev: v0.0.42
     hooks:
       - id: ty-check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ default-groups = "all"
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.14",
+    "ruff>=0.15.15",
     "ty>=0.0.40",
     "bandit>=1.9.4",
     "prek>=0.4.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3273,7 +3273,7 @@ dev = [
     { name = "jupytext", specifier = ">=1.19.1" },
     { name = "nbconvert", specifier = ">=7.17.1" },
     { name = "prek", specifier = ">=0.4.1" },
-    { name = "ruff", specifier = ">=0.15.14" },
+    { name = "ruff", specifier = ">=0.15.15" },
     { name = "ty", specifier = ">=0.0.40" },
     { name = "vulture", specifier = ">=2.16" },
 ]


### PR DESCRIPTION
This PR updates files via copier. In case of conflicts, the PR will always reflect the latest copier output.